### PR TITLE
Support excluding paths from generation of compilation database

### DIFF
--- a/src/api.mk
+++ b/src/api.mk
@@ -26,8 +26,11 @@ TARGETS :=
 # List of all test target names.
 TEST_TARGETS :=
 
-# List of paths to ignore during code coverage reporting.
-COVERAGE_BLACKLIST :=
+# List of paths to exclude from code coverage reporting.
+COVERAGE_EXCLUSIONS :=
+
+# List of paths to exclude from generation of compilation database.
+COMPILATION_DATABASE_EXCLUSIONS :=
 
 # Add a target to the build system. The target name must be unique. This name will be used to
 # generate file names for the target library/binary/etc. The target type may be one of:
@@ -80,15 +83,28 @@ endif
 
 endef
 
-# Add a path to the code coverage blacklist. The path may be a directory or file.
+# Add a path to the code coverage exclusion list. The path may be a directory or file.
 #
-# $(1) = The path relative to $(SOURCE_ROT) to ignore.
-define IGNORE_FOR_COVERAGE
+# $(1) = The path relative to $(SOURCE_ROOT) to exclude.
+define EXCLUDE_FROM_COVERAGE
 
 ifeq ($$(wildcard $(SOURCE_ROOT)/$$(strip $(1))),)
     $$(error Could not find path $$(strip $(1)), check your Makefile)
 endif
 
-COVERAGE_BLACKLIST += $(1)
+COVERAGE_EXCLUSIONS += $(1)
+
+endef
+
+# Add a path to the compilation database exclusion list. The path may be a directory or file.
+#
+# $(1) = The path relative to $(SOURCE_ROOT) to exclude.
+define EXCLUDE_FROM_COMPILATION_DATABASE
+
+ifeq ($$(wildcard $(SOURCE_ROOT)/$$(strip $(1))),)
+    $$(error Could not find path $$(strip $(1)), check your Makefile)
+endif
+
+COMPILATION_DATABASE_EXCLUSIONS += $(1)
 
 endef


### PR DESCRIPTION
Helps to keep the compilation database smaller if, for example, some
large third-party libraries are included in a build.