### PR TITLE
Move $(SHARED_LIB_EXT) definition to system.mk

### DIFF
--- a/src/compile.mk
+++ b/src/compile.mk
@@ -86,7 +86,7 @@ define LIB_RULES
 MAKEFILES_$(d) := $(BUILD_ROOT)/flags.mk $(wildcard $(d)/*.mk)
 
 STATIC_$$(t) := $(filter %.a,$(1))
-SHARED_$$(t) := $(filter %.so.$(VERSION) %.dylib.$(VERSION),$(1))
+SHARED_$$(t) := $(filter %.$(SHARED_LIB_EXT).$(VERSION),$(1))
 
 $$(STATIC_$$(t)) $$(SHARED_$$(t)): OBJS := $$(OBJ_$$(t))
 $$(STATIC_$$(t)) $$(SHARED_$$(t)): CFLAGS := $(CFLAGS_$(d)) $(CFLAGS)

--- a/src/release.mk
+++ b/src/release.mk
@@ -2,7 +2,7 @@
 # be used to add a file to the release package, or execute a command while creating the package. If
 # none of these APIs are used, no release package will be created.
 #
-# Any shared libraries added to the release package will also include a chain of symbolic links to
+# Any shared libraries added to the release package will also include a chain of symbolic links
 # which resolve to the real, versioned library defined by the application's Makefile. For example,
 # if the Makefile defines $(VERSION) as "1.0.0" and invokes $(ADD_TARGET) for a LIB target with the
 # name "libfly", the following symbolic link chain will be created under $(INSTALL_LIB_DIR):
@@ -14,15 +14,6 @@
 
 # A literal comma.
 COMMA := ,
-
-# System-dependent shared library extension.
-ifeq ($(SYSTEM), LINUX)
-    SHARED_LIB_EXT := so
-else ifeq ($(SYSTEM), MACOS)
-    SHARED_LIB_EXT := dylib
-else
-    $(error Unknown system $(SYSTEM), check release.mk)
-endif
 
 # Build the release package.
 define BUILD_REL

--- a/src/system.mk
+++ b/src/system.mk
@@ -44,3 +44,12 @@ endif
 ifneq ($(arch), $(filter $(SUPPORTED_ARCH), $(arch)))
     $(error Architecture $(arch) not supported, check system.mk)
 endif
+
+# System-dependent shared library extension.
+ifeq ($(SYSTEM), LINUX)
+    SHARED_LIB_EXT := so
+else ifeq ($(SYSTEM), MACOS)
+    SHARED_LIB_EXT := dylib
+else
+    $(error Unknown system $(SYSTEM), check system.mk)
+endif

--- a/src/target.mk
+++ b/src/target.mk
@@ -45,15 +45,8 @@ ifeq ($$(TARGET_TYPE_$$(t)), BIN)
         TEST_BINARIES += $$(TARGET_FILE_$$(t))
     endif
 else ifeq ($$(TARGET_TYPE_$$(t)), LIB)
-    ifeq ($(SYSTEM), LINUX)
-        TARGET_FILE_$$(t) := $(LIB_DIR)/$$(t).so.$(VERSION)
-        TARGET_FILE_$$(t) += $(LIB_DIR)/$$(t).a
-    else ifeq ($(SYSTEM), MACOS)
-        TARGET_FILE_$$(t) := $(LIB_DIR)/$$(t).dylib.$(VERSION)
-        TARGET_FILE_$$(t) += $(LIB_DIR)/$$(t).a
-    else
-        $$(error Unrecognized system $(SYSTEM), check target.mk)
-    endif
+    TARGET_FILE_$$(t) := $(LIB_DIR)/$$(t).$(SHARED_LIB_EXT).$(VERSION)
+    TARGET_FILE_$$(t) += $(LIB_DIR)/$$(t).a
 else ifeq ($$(TARGET_TYPE_$$(t)), JAR)
     TARGET_FILE_$$(t) := $(JAR_DIR)/$$(t)-$(VERSION).jar
 else ifeq ($$(TARGET_TYPE_$$(t)), PKG)


### PR DESCRIPTION
This reduces the number of places that need to check if .so or .dylib
should be used.