### PR TITLE
Remove x86 builds from CI

### DIFF
--- a/.azure.yml
+++ b/.azure.yml
@@ -14,25 +14,11 @@ jobs:
     parameters:
       toolchain: 'clang'
       mode: 'debug'
-      arch: 'x86'
-
-  - template: ci/linux.yml
-    parameters:
-      toolchain: 'clang'
-      mode: 'debug'
-      arch: 'x64'
 
   - template: ci/linux.yml
     parameters:
       toolchain: 'clang'
       mode: 'release'
-      arch: 'x86'
-
-  - template: ci/linux.yml
-    parameters:
-      toolchain: 'clang'
-      mode: 'release'
-      arch: 'x64'
 
   #### Linux GCC ####
 
@@ -40,25 +26,11 @@ jobs:
     parameters:
       toolchain: 'gcc'
       mode: 'debug'
-      arch: 'x86'
-
-  - template: ci/linux.yml
-    parameters:
-      toolchain: 'gcc'
-      mode: 'debug'
-      arch: 'x64'
 
   - template: ci/linux.yml
     parameters:
       toolchain: 'gcc'
       mode: 'release'
-      arch: 'x86'
-
-  - template: ci/linux.yml
-    parameters:
-      toolchain: 'gcc'
-      mode: 'release'
-      arch: 'x64'
 
   #### macOS ####
 

--- a/ci/linux.yml
+++ b/ci/linux.yml
@@ -1,10 +1,9 @@
 parameters:
   toolchain: 'clang'
   mode: 'debug'
-  arch: 'x64'
 
 jobs:
-  - job: 'Linux_${{ parameters.toolchain }}_${{ parameters.mode }}_${{ parameters.arch }}'
+  - job: 'Linux_${{ parameters.toolchain }}_${{ parameters.mode }}'
 
     pool:
       vmImage: ubuntu-20.04
@@ -21,7 +20,7 @@ jobs:
       failOnStderr: true
 
     - script: |
-        echo "##vso[task.setvariable variable=config]mode=${{ parameters.mode }} toolchain=${{ parameters.toolchain }} arch=${{ parameters.arch }}"
+        echo "##vso[task.setvariable variable=config]mode=${{ parameters.mode }} toolchain=${{ parameters.toolchain }}"
       displayName: 'Configure'
 
     - script: |
@@ -38,7 +37,6 @@ jobs:
 
     - ${{ if eq(parameters.toolchain, 'clang') }}:
       - ${{ if eq(parameters.mode, 'release') }}:
-        - ${{ if eq(parameters.arch, 'x64') }}:
-          - template: package.yml
-            parameters:
-              contents: 'out/flymake-*.tar.bz2'
+        - template: package.yml
+          parameters:
+            contents: 'out/flymake-*.tar.bz2'

--- a/ci/macos.yml
+++ b/ci/macos.yml
@@ -1,5 +1,5 @@
 parameters:
-  mode: 'Debug'
+  mode: 'debug'
 
 jobs:
   - job: 'macOS_${{ parameters.mode }}'


### PR DESCRIPTION
Just to reduce load on Azure Pipelines.